### PR TITLE
Data access via `resourcelib`

### DIFF
--- a/src/covariatetimeseries/timeseries_loader.py
+++ b/src/covariatetimeseries/timeseries_loader.py
@@ -1,7 +1,10 @@
 import pandas as pd
 
-DATASET_INFO_PATH='src/covariatetimeseries/data_collections/_collection_info.csv'
-DATASET_DIR_PATH="src/covariatetimeseries/data_collections"
+import importlib.resources
+
+DATASET_INFO_FILE = '_collection_info.csv'
+DATASET_MODULE = 'covariatetimeseries.data_collections'
+
 
 def load_timeseries(dataset_name, target_name, ts_name=None, other_targets_as_covs=True, exclude_time_covariates=False, verbose=False):
     """
@@ -19,11 +22,15 @@ def load_timeseries(dataset_name, target_name, ts_name=None, other_targets_as_co
         pandas.DataFrame: The loaded dataframe with the time series.
     """
 
-    table_df = pd.read_csv(DATASET_INFO_PATH, sep=';')
+    dataset_location = importlib.resources.files(DATASET_MODULE)
+    with importlib.resources.as_file(dataset_location) as dataset_dir:
+        table_df = pd.read_csv(dataset_dir / DATASET_INFO_FILE, sep=';')
 
     dataset_info = table_df[table_df["name"] == dataset_name].iloc[0]
 
-    file_path = f"{DATASET_DIR_PATH}/{dataset_name}.csv"
+
+    with importlib.resources.as_file(dataset_location) as dataset_dir:
+        file_path = dataset_dir / f"{dataset_name}.csv"
     try:
         df = pd.read_csv(file_path, sep=';')
 


### PR DESCRIPTION
Ensures that data is accessible if package is build (e.g., a wheel) and distributed.

Reproduce issue on `main`:

* Build with `uv build --wheel`.
* Create a new folder somewhere and go there.
* Run `uv venv` and `uv pip install path/to/covariatetimeseries/dist/covariatetimeseries-1.0-py3-none-any.whl`.
* Start python and execute
```
import covariatetimeseries

covariatetimeseries.load_timeseries("air_quality", "CO")
```